### PR TITLE
Add "output should match baseline" cucumber step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ lint: tekton-lint ## Run linter
 
 .PHONY: lint-fix
 lint-fix: ## Fix linting issues automagically
-	@go run -modfile tools/go.mod github.com/google/addlicense -c $(COPY) -s -ignore 'dist/reference/*.yaml' .
+	@go run -modfile tools/go.mod github.com/google/addlicense -c $(COPY) -s -ignore "configs/*/*.yaml" -ignore 'dist/reference/*.yaml' .
 	@go run -modfile tools/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint run --fix
 # We don't apply the fixes from the internal (error handling) linter.
 # TODO: fix the outstanding error handling lint issues and enable the fixer

--- a/acceptance/baselines/happy-output.json
+++ b/acceptance/baselines/happy-output.json
@@ -1,0 +1,46 @@
+{
+  "success": true,
+  "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
+  "key": ${known_PUBLIC_KEY_JSON},
+  "components": [
+	{
+	  "name": "Unnamed",
+	  "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
+	  "successes": [
+		{
+		  "msg": "Pass",
+		  "metadata": {
+			"code": "builtin.attestation.signature_check"
+		  }
+		},
+		{
+		  "msg": "Pass",
+		  "metadata": {
+			"code": "builtin.attestation.syntax_check"
+		  }
+		},
+		{
+		  "msg": "Pass",
+		  "metadata": {
+			"code": "builtin.image.signature_check"
+		  }
+		},
+		{
+		  "msg": "Pass",
+		  "metadata": {
+			"code": "main.acceptor"
+		  }
+		}
+	  ],
+	  "success": true,
+	  "signatures": ${ATTESTATION_SIGNATURES_JSON}
+	}
+  ],
+  "policy": {
+	"publicKey": "${known_PUBLIC_KEY}",
+	"rekorUrl": "${REKOR}",
+	"sources": [
+	  { "policy": ["git::https://${GITHOST}/git/happy-day-policy.git"] }
+	]
+  }
+}

--- a/acceptance/cli/cli.go
+++ b/acceptance/cli/cli.go
@@ -484,6 +484,18 @@ func theStandardErrorShouldContain(ctx context.Context, expected *godog.DocStrin
 	return fmt.Errorf("expected error:\n%s\nnot found in standard error:\n%s", expected, stderr)
 }
 
+// theStandardOutputShouldMatchBaseline reads the expected text from a file instead of directly
+// from the feature file
+func theStandardOutputShouldMatchBaseline(ctx context.Context, fileName string) error {
+	b, err := os.ReadFile(path.Join("acceptance", fileName))
+	if err != nil {
+		return err
+	}
+
+	docString := godog.DocString{Content: string(b)}
+	return theStandardOutputShouldContain(ctx, &docString)
+}
+
 func filterMatchedByRegexp(obj any, diff gojsondiff.Diff) diffy {
 	deltas := diff.Deltas()
 	if v, ok := obj.(map[string]any); ok {
@@ -669,6 +681,7 @@ func AddStepsTo(sc *godog.ScenarioContext) {
 	sc.Step(`^ec command is run with "(.+)"$`, ecCommandIsRunWith)
 	sc.Step(`^the exit status should be (\d+)$`, theExitStatusIs)
 	sc.Step(`^the standard output should contain$`, theStandardOutputShouldContain)
+	sc.Step(`^the standard output should match baseline file "(.+)"$`, theStandardOutputShouldMatchBaseline)
 	sc.Step(`^the standard error should contain$`, theStandardErrorShouldContain)
 	sc.Step(`^the environment variable is set "([^"]*)"$`, theEnvironmentVarilableIsSet)
 	sc.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {

--- a/acceptance/examples/happy-config.yaml
+++ b/acceptance/examples/happy-config.yaml
@@ -1,0 +1,3 @@
+sources:
+  - policy:
+      - "git::https://${GITHOST}/git/happy-day-policy.git"

--- a/acceptance/git/git.go
+++ b/acceptance/git/git.go
@@ -33,6 +33,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"regexp"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -239,6 +240,12 @@ func createGitRepository(ctx context.Context, repositoryName string, files *godo
 		if err != nil {
 			return err
 		}
+
+		// Replace ${GITHOST} with the real git host.
+		// Used in acceptance/examples/default-policy.yaml
+		// Hopefully a noop for all other files.
+		re := regexp.MustCompile(regexp.QuoteMeta("${GITHOST}"))
+		b = []byte(re.ReplaceAllString(string(b), Host(ctx)))
 
 		err = os.WriteFile(dest, b, 0644)
 		if err != nil {

--- a/configs/default/policy.yaml
+++ b/configs/default/policy.yaml
@@ -1,0 +1,27 @@
+#
+# To use this configuration:
+#   ec validate image ... --policy github.com/enterprise-contract//configs/default.yaml?ref=main
+#
+description: >
+  Use the policy rules from the "minimal" collection. This and other collections are defined in
+  https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/release_policy.html#_available_rule_collections
+  The minimal collection is a small set of policy rules that should be easy to pass for brand new RHTAP users.
+  If a different policy configuration is desired, this resource can serve as a starting point. See the docs on
+  how to include and exclude rules at https://redhat-appstudio.github.io/docs.stonesoup.io/ec-policies/policy_configuration.html#_including_and_excluding_rules
+
+publicKey: "k8s://tekton-chains/public-key"
+
+sources:
+  - name: Default RHTAP Release Policies
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/release
+    data:
+      - github.com/enterprise-contract/ec-policies//data
+
+configuration:
+  include:
+    - "@minimal"
+  exclude:
+    # This can be removed once https://issues.redhat.com/browse/OCPBUGS-8428 is addressed
+    - step_image_registries

--- a/configs/everything/policy.yaml
+++ b/configs/everything/policy.yaml
@@ -1,0 +1,24 @@
+#
+# To use this configuration:
+#   ec validate image ... --policy github.com/enterprise-contract//configs/everything.yaml?ref=main
+#
+description: >
+  Identical to the default configuration, but apply every rule instead of just the rules
+  in the minimal collection.
+
+publicKey: "k8s://tekton-chains/public-key"
+
+sources:
+  - name: Default RHTAP Release Policies
+    policy:
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/release
+    data:
+      - github.com/enterprise-contract/ec-policies//data
+
+configuration:
+  include:
+    - "*"
+  exclude:
+    # This can be removed once https://issues.redhat.com/browse/OCPBUGS-8428 is addressed
+    - step_image_registries

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -31,55 +31,7 @@ Feature: evaluate enterprise contract
     """
     When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
     Then the exit status should be 0
-    Then the standard output should contain
-    """
-    {
-      "success": true,
-      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
-      "key": ${known_PUBLIC_KEY_JSON},
-      "components": [
-        {
-          "name": "Unnamed",
-          "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
-          "successes": [
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "builtin.attestation.signature_check"
-              }
-            },
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "builtin.attestation.syntax_check"
-              }
-            },
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "builtin.image.signature_check"
-              }
-            },
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "main.acceptor"
-              }
-            }
-          ],
-          "success": true,
-          "signatures": ${ATTESTATION_SIGNATURES_JSON}
-        }
-      ],
-      "policy": {
-        "publicKey": "${known_PUBLIC_KEY}",
-        "rekorUrl": "${REKOR}",
-        "sources": [
-          { "policy": ["git::https://${GITHOST}/git/happy-day-policy.git"] }
-        ]
-      }
-    }
-    """
+    Then the standard output should match baseline file "baselines/happy-output.json"
 
   Scenario: happy day with git url for config
     Given a key pair named "known"
@@ -94,55 +46,7 @@ Feature: evaluate enterprise contract
       | policy.yaml | examples/happy-config.yaml |
     When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy git::https://${GITHOST}/git/happy-config.git --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
     Then the exit status should be 0
-    Then the standard output should contain
-    """
-    {
-      "success": true,
-      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
-      "key": ${known_PUBLIC_KEY_JSON},
-      "components": [
-        {
-          "name": "Unnamed",
-          "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
-          "successes": [
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "builtin.attestation.signature_check"
-              }
-            },
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "builtin.attestation.syntax_check"
-              }
-            },
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "builtin.image.signature_check"
-              }
-            },
-            {
-              "msg": "Pass",
-              "metadata": {
-                "code": "main.acceptor"
-              }
-            }
-          ],
-          "success": true,
-          "signatures": ${ATTESTATION_SIGNATURES_JSON}
-        }
-      ],
-      "policy": {
-        "publicKey": "${known_PUBLIC_KEY}",
-        "rekorUrl": "${REKOR}",
-        "sources": [
-          { "policy": ["git::https://${GITHOST}/git/happy-day-policy.git"] }
-        ]
-      }
-    }
-    """
+    Then the standard output should match baseline file "baselines/happy-output.json"
 
   Scenario: happy day with keyless
     Given a signed and attested keyless image named "acceptance/ec-happy-day-keyless"

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -81,6 +81,69 @@ Feature: evaluate enterprise contract
     }
     """
 
+  Scenario: happy day with git url for config
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "happy-day-policy" with
+      | main.rego | examples/happy_day.rego |
+    Given a git repository named "happy-config" with
+      | policy.yaml | examples/happy-config.yaml |
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy git::https://${GITHOST}/git/happy-config.git --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
+    Then the exit status should be 0
+    Then the standard output should contain
+    """
+    {
+      "success": true,
+      "ec-version":"v\\d+.\\d+.\\d+-[0-9a-f]+",
+      "key": ${known_PUBLIC_KEY_JSON},
+      "components": [
+        {
+          "name": "Unnamed",
+          "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
+          "successes": [
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "builtin.attestation.signature_check"
+              }
+            },
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "builtin.attestation.syntax_check"
+              }
+            },
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "builtin.image.signature_check"
+              }
+            },
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "main.acceptor"
+              }
+            }
+          ],
+          "success": true,
+          "signatures": ${ATTESTATION_SIGNATURES_JSON}
+        }
+      ],
+      "policy": {
+        "publicKey": "${known_PUBLIC_KEY}",
+        "rekorUrl": "${REKOR}",
+        "sources": [
+          { "policy": ["git::https://${GITHOST}/git/happy-day-policy.git"] }
+        ]
+      }
+    }
+    """
+
   Scenario: happy day with keyless
     Given a signed and attested keyless image named "acceptance/ec-happy-day-keyless"
     Given a initialized tuf root

--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -71,9 +71,6 @@ CONFIG="$MINIMAL_CONFIG"
 # The ECP config. Modify as required.
 #
 POLICY="
-publicKey: |-
-$(echo "$PUBLIC_KEY" | sed 's/^/  /')
-
 sources:
   - name: EC Policies
     policy:
@@ -84,10 +81,20 @@ sources:
 ${CONFIG}
 "
 
+# Put this inside the double quotes above to add the public key to the ECP
+# config. Currently we're using the --public-key flag instead.
+#
+#publicKey: |-
+#$(echo "$PUBLIC_KEY" | sed 's/^/  /')
+
+# Uncomment one of these to use a config stored in git
+#POLICY="github.com/enterprise-contract/ec-cli//configs/default?ref=main"
+#POLICY="github.com/enterprise-contract/ec-cli//configs/everything?ref=main"
+
 # To show debug output:
 #   hack/simple-demo.sh --debug
 #
 OPTS=${1:-}
 
 MAIN_GO=$(git rev-parse --show-toplevel)/main.go
-go run $MAIN_GO validate image --json-input "${APPLICATION_SNAPSHOT}" --policy "${POLICY}" --info=true $OPTS | yq -P
+go run $MAIN_GO validate image --json-input "${APPLICATION_SNAPSHOT}" --policy "${POLICY}" --public-key <(echo "${PUBLIC_KEY}") --info=true $OPTS | yq -P

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -14,6 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// This module is more of a general purpose wrapper for fetching files and
+// saving them locally. It was originally used only for policy, i.e. rego and
+// yaml files, from the ec-policies repo, hence the name choice PolicySource,
+// but now it's also used for fetching configuration from a git url.
+
 package source
 
 import (
@@ -37,6 +42,7 @@ const (
 	DownloaderFuncKey key        = 0
 	PolicyKind        policyKind = "policy"
 	DataKind          policyKind = "data"
+	ConfigKind        policyKind = "config"
 )
 
 type downloaderFunc interface {
@@ -54,7 +60,7 @@ type PolicySource interface {
 type PolicyUrl struct {
 	// A string containing a go-getter style source url compatible with conftest pull
 	Url string
-	// Either "data" or "policy"
+	// Either "data", "policy", or "config"
 	Kind policyKind
 }
 


### PR DESCRIPTION
Having the long pieces of json output inline in the feature file was starting to feel messy. This tidies it up and also allows reuse.